### PR TITLE
Put User Policy & List User Policy Tests

### DIFF
--- a/s3tests_boto3/functional/test_iam.py
+++ b/s3tests_boto3/functional/test_iam.py
@@ -58,16 +58,12 @@ def test_put_user_policy_parameter_limit():
     client = get_tenant_iam_client()
 
     policy_document = json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                             {
-                                 "Effect": "Allow",
-                                 "Action": "*",
-                                 "Resource": "*"
-                             }
-                         ] * 1000
-        }
+        {"Version": "2012-10-17",
+         "Statement": [{
+             "Effect": "Allow",
+             "Action": "*",
+             "Resource": "*"}] * 1000
+         }
     )
     e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
                       PolicyName='AllAccessPolicy' * 10, UserName="some-non-existing-user-id")
@@ -85,16 +81,12 @@ def test_put_user_policy_invalid_element():
 
     # With Version other than 2012-10-17
     policy_document = json.dumps(
-        {
-            "Version": "2010-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": "*",
-                    "Resource": "*"
-                }
-            ]
-        }
+        {"Version": "2010-10-17",
+         "Statement": [{
+             "Effect": "Allow",
+             "Action": "*",
+             "Resource": "*"}]
+         }
     )
     e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
                       PolicyName='AllAccessPolicy', UserName="some-non-existing-user-id")
@@ -114,23 +106,17 @@ def test_put_user_policy_invalid_element():
 
     # with same Sid for 2 statements
     policy_document = json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "98AB54CF",
-                    "Effect": "Allow",
-                    "Action": "*",
-                    "Resource": "*"
-                },
-                {
-                    "Sid": "98AB54CF",
-                    "Effect": "Allow",
-                    "Action": "*",
-                    "Resource": "*"
-                }
-            ]
-        }
+        {"Version": "2012-10-17",
+         "Statement": [
+             {"Sid": "98AB54CF",
+              "Effect": "Allow",
+              "Action": "*",
+              "Resource": "*"},
+             {"Sid": "98AB54CF",
+              "Effect": "Allow",
+              "Action": "*",
+              "Resource": "*"}]
+         }
     )
     e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
                       PolicyName='AllAccessPolicy', UserName="some-non-existing-user-id")
@@ -139,17 +125,13 @@ def test_put_user_policy_invalid_element():
 
     # with Principal
     policy_document = json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": "*",
-                    "Resource": "*",
-                    "Principal": "arn:aws:iam:::username"
-                }
-            ]
-        }
+        {"Version": "2012-10-17",
+         "Statement": [{
+             "Effect": "Allow",
+             "Action": "*",
+             "Resource": "*",
+             "Principal": "arn:aws:iam:::username"}]
+         }
     )
     e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
                       PolicyName='AllAccessPolicy', UserName="some-non-existing-user-id")
@@ -170,7 +152,8 @@ def test_put_existing_user_policy():
          "Statement": {
              "Effect": "Allow",
              "Action": "*",
-             "Resource": "*"}}
+             "Resource": "*"}
+         }
     )
     client.put_user_policy(PolicyDocument=policy_document, PolicyName='AllAccessPolicy',
                            UserName=get_tenant_user_id())
@@ -191,7 +174,8 @@ def test_list_user_policy():
          "Statement": {
              "Effect": "Allow",
              "Action": "*",
-             "Resource": "*"}}
+             "Resource": "*"}
+         }
     )
     client.put_user_policy(PolicyDocument=policy_document, PolicyName='AllAccessPolicy',
                            UserName=get_tenant_user_id())
@@ -204,7 +188,7 @@ def test_list_user_policy():
 @attr(operation='Verify List User policies with invalid user')
 @attr(assertion='succeeds')
 @attr('user-policy')
-def test_list_user_policy_invalid_user_():
+def test_list_user_policy_invalid_user():
     client = get_tenant_iam_client()
     e = assert_raises(ClientError, client.list_user_policies, UserName="some-non-existing-user-id")
     status = _get_status(e.response)

--- a/s3tests_boto3/functional/test_iam.py
+++ b/s3tests_boto3/functional/test_iam.py
@@ -26,6 +26,7 @@ def test_put_user_policy():
     )
     client.put_user_policy(PolicyDocument=policy_document, PolicyName='AllAccessPolicy',
                            UserName=get_tenant_user_id())
+    client.delete_user_policy(PolicyName='AllAccessPolicy', UserName=get_tenant_user_id())
 
 
 @attr(resource='user-policy')
@@ -159,6 +160,7 @@ def test_put_existing_user_policy():
                            UserName=get_tenant_user_id())
     client.put_user_policy(PolicyDocument=policy_document, PolicyName='AllAccessPolicy',
                            UserName=get_tenant_user_id())
+    client.delete_user_policy(PolicyName='AllAccessPolicy', UserName=get_tenant_user_id())
 
 
 @attr(resource='user-policy')
@@ -181,6 +183,7 @@ def test_list_user_policy():
                            UserName=get_tenant_user_id())
     response = client.list_user_policies(UserName=get_tenant_user_id())
     eq("AllAccessPolicy" in response["PolicyNames"], True)
+    client.delete_user_policy(PolicyName='AllAccessPolicy', UserName=get_tenant_user_id())
 
 
 @attr(resource='user-policy')

--- a/s3tests_boto3/functional/test_iam.py
+++ b/s3tests_boto3/functional/test_iam.py
@@ -14,8 +14,7 @@ from .utils import _get_status
 @attr(operation='Verify Put User Policy')
 @attr(assertion='succeeds')
 @attr('user-policy')
-def test_put_user_policy_40447():
-    """TEST-40447"""
+def test_put_user_policy():
     client = get_tenant_iam_client()
 
     policy_document = json.dumps(
@@ -34,8 +33,7 @@ def test_put_user_policy_40447():
 @attr(operation='Verify Put User Policy with invalid user')
 @attr(assertion='succeeds')
 @attr('user-policy')
-def test_put_user_policy_invalid_user_40449():
-    """TEST-40449"""
+def test_put_user_policy_invalid_user():
     client = get_tenant_iam_client()
 
     policy_document = json.dumps(
@@ -56,8 +54,7 @@ def test_put_user_policy_invalid_user_40449():
 @attr(operation='Verify Put User Policy using parameter value outside limit')
 @attr(assertion='succeeds')
 @attr('user-policy')
-def test_put_user_policy_parameter_limit_40450():
-    """TEST-40450"""
+def test_put_user_policy_parameter_limit():
     client = get_tenant_iam_client()
 
     policy_document = json.dumps(
@@ -83,8 +80,7 @@ def test_put_user_policy_parameter_limit_40450():
 @attr(operation='Verify Put User Policy using invalid policy document elements')
 @attr(assertion='succeeds')
 @attr('user-policy')
-def test_put_user_policy_invalid_element_40451():
-    """TEST-40451"""
+def test_put_user_policy_invalid_element():
     client = get_tenant_iam_client()
 
     # With Version other than 2012-10-17
@@ -166,8 +162,7 @@ def test_put_user_policy_invalid_element_40451():
 @attr(operation='Verify Put a policy that already exists')
 @attr(assertion='succeeds')
 @attr('user-policy')
-def test_put_existing_user_policy_40452():
-    """TEST-40452"""
+def test_put_existing_user_policy():
     client = get_tenant_iam_client()
 
     policy_document = json.dumps(
@@ -188,8 +183,7 @@ def test_put_existing_user_policy_40452():
 @attr(operation='Verify List User policies')
 @attr(assertion='succeeds')
 @attr('user-policy')
-def test_list_user_policy_40453():
-    """TEST-40453"""
+def test_list_user_policy():
     client = get_tenant_iam_client()
 
     policy_document = json.dumps(
@@ -210,8 +204,7 @@ def test_list_user_policy_40453():
 @attr(operation='Verify List User policies with invalid user')
 @attr(assertion='succeeds')
 @attr('user-policy')
-def test_list_user_policy_invalid_user_40454():
-    """TEST-40454"""
+def test_list_user_policy_invalid_user_():
     client = get_tenant_iam_client()
     e = assert_raises(ClientError, client.list_user_policies, UserName="some-non-existing-user-id")
     status = _get_status(e.response)

--- a/s3tests_boto3/functional/test_iam.py
+++ b/s3tests_boto3/functional/test_iam.py
@@ -1,0 +1,218 @@
+import json
+from operator import eq
+
+from botocore.exceptions import ClientError
+from nose.plugins.attrib import attr
+
+from s3tests.functional.utils import assert_raises
+from . import get_tenant_iam_client, get_tenant_user_id
+from .utils import _get_status
+
+
+@attr(resource='user-policy')
+@attr(method='put')
+@attr(operation='Verify Put User Policy')
+@attr(assertion='succeeds')
+@attr('user-policy')
+def test_put_user_policy_40447():
+    """TEST-40447"""
+    client = get_tenant_iam_client()
+
+    policy_document = json.dumps(
+        {"Version": "2012-10-17",
+         "Statement": {
+             "Effect": "Allow",
+             "Action": "*",
+             "Resource": "*"}}
+    )
+    client.put_user_policy(PolicyDocument=policy_document, PolicyName='AllAccessPolicy',
+                           UserName=get_tenant_user_id())
+
+
+@attr(resource='user-policy')
+@attr(method='put')
+@attr(operation='Verify Put User Policy with invalid user')
+@attr(assertion='succeeds')
+@attr('user-policy')
+def test_put_user_policy_invalid_user_40449():
+    """TEST-40449"""
+    client = get_tenant_iam_client()
+
+    policy_document = json.dumps(
+        {"Version": "2012-10-17",
+         "Statement": {
+             "Effect": "Allow",
+             "Action": "*",
+             "Resource": "*"}}
+    )
+    e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
+                      PolicyName='AllAccessPolicy', UserName="some-non-existing-user-id")
+    status = _get_status(e.response)
+    eq(status, 404)
+
+
+@attr(resource='user-policy')
+@attr(method='put')
+@attr(operation='Verify Put User Policy using parameter value outside limit')
+@attr(assertion='succeeds')
+@attr('user-policy')
+def test_put_user_policy_parameter_limit_40450():
+    """TEST-40450"""
+    client = get_tenant_iam_client()
+
+    policy_document = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                             {
+                                 "Effect": "Allow",
+                                 "Action": "*",
+                                 "Resource": "*"
+                             }
+                         ] * 1000
+        }
+    )
+    e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
+                      PolicyName='AllAccessPolicy' * 10, UserName="some-non-existing-user-id")
+    status = _get_status(e.response)
+    eq(status, 400)
+
+
+@attr(resource='user-policy')
+@attr(method='put')
+@attr(operation='Verify Put User Policy using invalid policy document elements')
+@attr(assertion='succeeds')
+@attr('user-policy')
+def test_put_user_policy_invalid_element_40451():
+    """TEST-40451"""
+    client = get_tenant_iam_client()
+
+    # With Version other than 2012-10-17
+    policy_document = json.dumps(
+        {
+            "Version": "2010-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "*",
+                    "Resource": "*"
+                }
+            ]
+        }
+    )
+    e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
+                      PolicyName='AllAccessPolicy', UserName="some-non-existing-user-id")
+    status = _get_status(e.response)
+    eq(status, 400)
+
+    # With no Statement
+    policy_document = json.dumps(
+        {
+            "Version": "2012-10-17",
+        }
+    )
+    e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
+                      PolicyName='AllAccessPolicy', UserName="some-non-existing-user-id")
+    status = _get_status(e.response)
+    eq(status, 400)
+
+    # with same Sid for 2 statements
+    policy_document = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "98AB54CF",
+                    "Effect": "Allow",
+                    "Action": "*",
+                    "Resource": "*"
+                },
+                {
+                    "Sid": "98AB54CF",
+                    "Effect": "Allow",
+                    "Action": "*",
+                    "Resource": "*"
+                }
+            ]
+        }
+    )
+    e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
+                      PolicyName='AllAccessPolicy', UserName="some-non-existing-user-id")
+    status = _get_status(e.response)
+    eq(status, 400)
+
+    # with Principal
+    policy_document = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "*",
+                    "Resource": "*",
+                    "Principal": "arn:aws:iam:::username"
+                }
+            ]
+        }
+    )
+    e = assert_raises(ClientError, client.put_user_policy, PolicyDocument=policy_document,
+                      PolicyName='AllAccessPolicy', UserName="some-non-existing-user-id")
+    status = _get_status(e.response)
+    eq(status, 400)
+
+
+@attr(resource='user-policy')
+@attr(method='put')
+@attr(operation='Verify Put a policy that already exists')
+@attr(assertion='succeeds')
+@attr('user-policy')
+def test_put_existing_user_policy_40452():
+    """TEST-40452"""
+    client = get_tenant_iam_client()
+
+    policy_document = json.dumps(
+        {"Version": "2012-10-17",
+         "Statement": {
+             "Effect": "Allow",
+             "Action": "*",
+             "Resource": "*"}}
+    )
+    client.put_user_policy(PolicyDocument=policy_document, PolicyName='AllAccessPolicy',
+                           UserName=get_tenant_user_id())
+    client.put_user_policy(PolicyDocument=policy_document, PolicyName='AllAccessPolicy',
+                           UserName=get_tenant_user_id())
+
+
+@attr(resource='user-policy')
+@attr(method='put')
+@attr(operation='Verify List User policies')
+@attr(assertion='succeeds')
+@attr('user-policy')
+def test_list_user_policy_40453():
+    """TEST-40453"""
+    client = get_tenant_iam_client()
+
+    policy_document = json.dumps(
+        {"Version": "2012-10-17",
+         "Statement": {
+             "Effect": "Allow",
+             "Action": "*",
+             "Resource": "*"}}
+    )
+    client.put_user_policy(PolicyDocument=policy_document, PolicyName='AllAccessPolicy',
+                           UserName=get_tenant_user_id())
+    response = client.list_user_policies(UserName=get_tenant_user_id())
+    eq("AllAccessPolicy" in response["PolicyNames"], True)
+
+
+@attr(resource='user-policy')
+@attr(method='put')
+@attr(operation='Verify List User policies with invalid user')
+@attr(assertion='succeeds')
+@attr('user-policy')
+def test_list_user_policy_invalid_user_40454():
+    """TEST-40454"""
+    client = get_tenant_iam_client()
+    e = assert_raises(ClientError, client.list_user_policies, UserName="some-non-existing-user-id")
+    status = _get_status(e.response)
+    eq(status, 404)


### PR DESCRIPTION
* Test Design: [F-20E: S3: API: IAM Policy Support](https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/980255029/F-20E+S3+API+IAM+Policy+Support+-+PI7)
* Executed on Ceph Quincy and Cortx-2.0.0-744
* Logs:
    ```
    [root s3-tests]# S3TEST_CONF=s3tests.conf ./virtualenv/bin/nosetests s3tests_boto3.functional.test_iam
    /root/ketan/s3-tests/virtualenv/lib/python3.6/site-packages/boto3/compat.py:88: PythonDeprecationWarning: Boto3 will no longer support Python 3.6 starting May 30, 2022. To continue receiving service updates, bug fixes, and security updates please upgrade to Python 3.7 or later. More information can be found here: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/
      warnings.warn(warning, PythonDeprecationWarning)
    .......
    ----------------------------------------------------------------------
    Ran 7 tests in 0.638s
    ```